### PR TITLE
fix readable One-dimensional numpy.

### DIFF
--- a/imgcat/imgcat.py
+++ b/imgcat/imgcat.py
@@ -102,6 +102,8 @@ def to_content_buf(data):
             im = im.astype(sys.modules['numpy'].uint8)
         elif len(im.shape) == 3 and im.shape[2] in (3, 4):
             mode = None    # RGB/RGBA
+        elif len(im.shape) == 1:
+            return im.tostring()
         else:
             raise ValueError("Expected a 3D ndarray (RGB/RGBA image) or 2D (grayscale image), "
                              "but given shape: {}".format(im.shape))


### PR DESCRIPTION
fix readable One-dimensional numpy.

example.

```py
import numpy
from imgcat import imgcat

path = 'evaluation/car1.jpg'
with open(path, 'rb') as f:
    data = numpy.frombuffer(f.read(), dtype="uint8")

print(data.shape) # => (37379,) one-dimensional ndarray
imgcat(data)
```
